### PR TITLE
Show all articles on knowledge page

### DIFF
--- a/resources/views/knowledge.antlers.html
+++ b/resources/views/knowledge.antlers.html
@@ -6,7 +6,7 @@
 <section class="knowledge-list">
   <h2>Artikler</h2>
 
-  {{ collection:articles }}
+  {{ collection:articles status="*" }}
     <article>
       <h3><a href="{{ url }}">{{ title }}</a></h3>
     </article>


### PR DESCRIPTION
### Motivation
- The knowledge page was only listing published entries from the `articles` collection, so some items (e.g. drafts) were not showing up; the intent is to surface all articles regardless of status.

### Description
- Update `resources/views/knowledge.antlers.html` to use `{{ collection:articles status="*" }}` instead of the default `{{ collection:articles }}` so the page includes entries with any status.

### Testing
- No automated tests were run; an attempt to start the app with `php artisan serve` failed due to a missing `vendor/autoload.php`, preventing local verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69721a30312c8328b8ab3148335548cc)