### PR TITLE
Update AI suggestion handling to new `data-suggestion` UI and support `include_recent` auto-submit

### DIFF
--- a/resources/js/site.js
+++ b/resources/js/site.js
@@ -8,6 +8,7 @@ function initAiChat(root) {
   const input = form?.querySelector('input[name="message"]');
   const tagInput = form?.querySelector('input[name="tag"]');
   const collectionInput = form?.querySelector('input[name="collection"]');
+  const includeRecentInput = form?.querySelector("[data-include-recent-input]");
   const suggestions = root.querySelector("[data-ai-suggestions]");
 
   if (!form || !messages || !input) return;
@@ -138,12 +139,25 @@ function initAiChat(root) {
   suggestions?.addEventListener("click", (event) => {
     const target = event.target;
     if (!(target instanceof HTMLElement)) return;
-    if (!target.classList.contains("ai-suggestion")) return;
 
-    const suggestionText = target.textContent?.trim();
+    const suggestionEl = target.closest("[data-suggestion]");
+    if (!(suggestionEl instanceof HTMLElement)) return;
+
+    const suggestionText = suggestionEl.dataset.suggestion?.trim();
     if (!suggestionText) return;
 
     input.value = suggestionText;
+
+    if (includeRecentInput) {
+      const includeRecent = suggestionEl.dataset.includeRecent === "1";
+      includeRecentInput.value = includeRecent ? "1" : "0";
+
+      if (includeRecent) {
+        form.requestSubmit();
+        return;
+      }
+    }
+
     input.focus();
   });
 }


### PR DESCRIPTION
### Motivation
- The suggestion UI was replaced with elements that expose suggestion text via a `data-suggestion` attribute instead of clickable `.ai-suggestion` elements. 
- Weekly-summary quick actions need to trigger the form submission while also including the `include_recent` flag so the backend can include recent notes. 
- Keep the chat form behavior intact so normal suggestions populate the input without immediately submitting.

### Description
- Added a reference to the hidden `include_recent` input via `const includeRecentInput = form?.querySelector("[data-include-recent-input]")` so the JS can read and set the flag. 
- Rewrote suggestion click handling to use `target.closest('[data-suggestion]')` and read the suggestion text from `dataset.suggestion` to match the new UI. 
- When a suggestion has `data-include-recent="1"` the script sets the hidden input to `"1"` and calls `form.requestSubmit()` to auto-submit the weekly-summary quick action. 
- For non-auto-submit suggestions the text is populated into the input and input focus is preserved; the `include_recent` input is reset to `"0"` after a request completes as before. 

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a0d4a33988328b411fe5afba72cf2)