### PR TITLE
Update notes list layout

### DIFF
--- a/resources/css/site.css
+++ b/resources/css/site.css
@@ -274,25 +274,25 @@ body {
 .notes-panel__list {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 0;
+  border-top: 1px solid #e5e7eb;
 }
 
 .note-card {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding: 14px;
-  border-radius: 14px;
-  border: 1px solid #e5e7eb;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 6px;
+  border-bottom: 1px solid #e5e7eb;
   text-decoration: none;
   color: inherit;
-  transition: transform 150ms ease, box-shadow 150ms ease;
-  background: #fafafa;
+  transition: background 150ms ease;
+  background: transparent;
 }
 
 .note-card:hover {
-  transform: translateY(-2px);
-  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+  background: #f9fafb;
 }
 
 .note-card__title {
@@ -300,10 +300,17 @@ body {
   font-weight: 600;
 }
 
+.note-card__meta {
+  font-size: 0.85rem;
+  color: #6b7280;
+  white-space: nowrap;
+}
+
 .note-card__tags {
   display: flex;
   flex-wrap: wrap;
   gap: 6px;
+  justify-self: end;
 }
 
 .tag {
@@ -325,6 +332,19 @@ body {
 
   .ai-chat__context {
     align-self: flex-start;
+  }
+
+  .note-card {
+    grid-template-columns: 1fr;
+    align-items: flex-start;
+  }
+
+  .note-card__meta {
+    order: 2;
+  }
+
+  .note-card__tags {
+    justify-self: start;
   }
 }
 

--- a/resources/views/home.antlers.html
+++ b/resources/views/home.antlers.html
@@ -99,7 +99,9 @@
           data-updated-at="{{ updated_at }}"
         >
           <div class="note-card__title">{{ title }}</div>
-          <div class="note-card__meta">Oppdatert {{ updated_at format="d.m.Y" }}</div>
+          <time class="note-card__meta" datetime="{{ updated_at format='Y-m-d' }}">
+            Oppdatert {{ updated_at format="d.m.Y" }}
+          </time>
           {{ if tags }}
             <div class="note-card__tags">
               {{ tags }}


### PR DESCRIPTION
### Motivation
- Render notes as a compact, row-based list to make titles, updated dates and tags easier to scan. 
- Remove heavy card backgrounds/shadows in favor of subtle separators and transparent backgrounds to match the cleaner list design.

### Description
- Update layout rules in `resources/css/site.css` to convert `.note-card` into a three-column grid with `grid-template-columns: minmax(0, 1fr) auto auto`, apply a `border-bottom` separator, remove the card background/shadow, and add a subtle hover background. 
- Add responsive stacking rules so notes collapse to a single-column layout on small screens and metadata/tags reorder appropriately. 
- Change the updated date markup in `resources/views/home.antlers.html` to a semantic `<time>` element (using `datetime`), while preserving existing `data-` attributes such as `data-note-item` and `data-updated-at` so weekly filtering/JS population continues to work.

### Testing
- Installed PHP dependencies with `composer install`, which completed successfully. 
- Started the dev server with `php artisan serve` and performed a visual smoke test by capturing a screenshot via Playwright (screenshot artifact produced), confirming the new list layout renders; no unit tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a0d48220c8328b590b3d4ab6e97f7)