### PR TITLE
Fix Antlers template structure in home view

### DIFF
--- a/resources/views/home.antlers.html
+++ b/resources/views/home.antlers.html
@@ -33,6 +33,7 @@
           </button>
         </div>
       </div>
+    </form>
       <nav class="app-sidebar__nav">
         <div class="app-sidebar__section">
           <h3 class="app-sidebar__title">GPT-er</h3>
@@ -81,34 +82,6 @@
             </strong>
           </div>
         </header>
-
-    <div class="notes-panel__header notes-panel__header--compact">
-      <h3>Alle notater</h3>
-      <p>Hold oversikt og åpne direkte for mer detaljer.</p>
-    </div>
-    <div class="notes-panel__list">
-      {{ collection:articles sort="updated_at:desc" taxonomy:tags="{get:tag}" }}
-        <a
-          class="note-card"
-          href="{{ url }}"
-          data-note-item
-          data-updated-at="{{ updated_at }}"
-        >
-          <div class="note-card__title">{{ title }}</div>
-          <time class="note-card__meta" datetime="{{ updated_at format='Y-m-d' }}">
-            Oppdatert {{ updated_at format="d.m.Y" }}
-          </time>
-          {{ if tags }}
-            <div class="note-card__tags">
-              {{ tags }}
-                <span class="tag">{{ title }}</span>
-              {{ /tags }}
-            </div>
-            <p class="ai-chat__footnote">Enter for å sende · Shift + Enter for ny linje</p>
-          </form>
-        </section>
-      </div>
-
       <section class="notes-panel notes-panel--chatgpt">
         <div class="notes-panel__header">
           <div>
@@ -144,6 +117,7 @@
           {{ /collection:articles }}
         </div>
       </section>
+      </div>
     </section>
   </div>
 </main>


### PR DESCRIPTION
### Motivation
- The Antlers template in `resources/views/home.antlers.html` contained duplicated notes-panel markup and an unclosed form/control structure which caused a SyntaxErrorException about an unclosed `if` block.

### Description
- Removed the duplicated notes panel fragment that left control structures unbalanced.
- Closed the chat form (`</form>`) that was left open inside the sidebar.
- Added the missing closing wrapper (`</div>`) for the main canvas area to restore valid markup. 
- Ensured the `{{ collection:articles }}` and `{{ if tags }}` blocks remain balanced and the template structure is consistent.

### Testing
- Inspected and validated the updated file structure using `sed`, `rg`, and `nl` to confirm tag and block placements, which showed the corrected layout. 
- Attempted to run the dev server with `php artisan serve`, which failed due to a missing `vendor/autoload.php` in this environment. 
- Executed a Playwright script to capture a screenshot artifact of the site UI, which produced an artifact but could not fully validate runtime rendering because the local PHP server failed to start. 
- Committed the change with a descriptive message (`Fix Antlers template structure`) successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a0fe724148328a34abca7469ae7e6)